### PR TITLE
Replace die with exception for cleaner error handling

### DIFF
--- a/lib/Fhp/Parser/MT940.php
+++ b/lib/Fhp/Parser/MT940.php
@@ -104,7 +104,7 @@ class MT940
                     } elseif ($trxMatch[2] == 'D') {
                         $trx[count($trx)]['credit_debit'] = static::CD_DEBIT;
                     } else {
-                        die('cd mark not found in: ' . $transaction);
+                        throw new MT940Exception('cd mark not found in: ' . $transaction);
                     }
 
                     $amount = $trxMatch[4];


### PR DESCRIPTION
I think it would be better to throw an exception, instead of using die().

If the script just dies the enduser will just get an ugly error, which he doesn't understand anyway. An exception is catchable and we could write something into an error log and display a nice error message.

Thoughts on that one?