### PR TITLE
Fixed a bug where a single quote code lead into an parse error

### DIFF
--- a/lib/Fhp/Response/Response.php
+++ b/lib/Fhp/Response/Response.php
@@ -21,7 +21,7 @@ class Response
     protected $response;
 
     /** @var array */
-    protected $segments = [];
+    protected $segments = array();
 
     /** @var string */
     protected $dialogId;
@@ -42,7 +42,7 @@ class Response
 
         $this->rawResponse = $rawResponse;
         $this->response = $this->unwrapEncryptedMsg($rawResponse);
-        $this->segments = preg_split("#(')(?=[A-Z]{4,}:\d|')#", $rawResponse);
+        $this->segments = preg_split("#'(?=[A-Z]{4,}:\d|')#", $rawResponse);
     }
 
     /**
@@ -90,7 +90,7 @@ class Response
      */
     public function getTouchDowns(AbstractMessage $message)
     {
-        $touchdown = [];
+        $touchdown = array();
         $messageSegments = $message->getEncryptedSegments();
         /** @var AbstractSegment $msgSeg */
         foreach ($messageSegments as $msgSeg) {
@@ -197,11 +197,11 @@ class Response
      */
     protected function getSummaryBySegment($name)
     {
-        if (!in_array($name, ['HIRMS', 'HIRMG'])) {
+        if (!in_array($name, array('HIRMS', 'HIRMG'))) {
             throw new \Exception('Invalid segment for message summary. Only HIRMS and HIRMG supported');
         }
 
-        $result = [];
+        $result = array();
         $segment = $this->findSegment($name);
         $segment = $this->splitSegment($segment);
         array_shift($segment);
@@ -257,8 +257,8 @@ class Response
     public function humanReadable($translateCodes = false)
     {
         return str_replace(
-            ["'", '+'],
-            [PHP_EOL, PHP_EOL . "  "],
+            array("'", '+'),
+            array(PHP_EOL, PHP_EOL . "  "),
             $translateCodes
                 ? NameMapping::translateResponse($this->rawResponse)
                 : $this->rawResponse
@@ -305,7 +305,7 @@ class Response
      */
     protected function findSegments($name, $one = false)
     {
-        $found = $one ? null : [];
+        $found = $one ? null : array();
 
         foreach ($this->segments as $segment) {
             $split = explode(':', $segment, 2);

--- a/lib/Fhp/Response/Response.php
+++ b/lib/Fhp/Response/Response.php
@@ -42,7 +42,7 @@ class Response
 
         $this->rawResponse = $rawResponse;
         $this->response = $this->unwrapEncryptedMsg($rawResponse);
-        $this->segments = preg_split("#(')(?=[A-Z]{4,})#", $rawResponse);
+        $this->segments = preg_split("#(')(?=[A-Z]{4,}:\d|')#", $rawResponse);
     }
 
     /**

--- a/lib/Fhp/Response/Response.php
+++ b/lib/Fhp/Response/Response.php
@@ -8,18 +8,24 @@ use Fhp\Segment\NameMapping;
 
 /**
  * Class Response
+ *
  * @package Fhp\Response
  */
 class Response
 {
+
     /** @var string */
     public $rawResponse;
+
     /** @var string */
     protected $response;
+
     /** @var array */
-    protected $segments = array();
+    protected $segments = [];
+
     /** @var string */
     protected $dialogId;
+
     /** @var string */
     protected $systemId;
 
@@ -35,8 +41,8 @@ class Response
         }
 
         $this->rawResponse = $rawResponse;
-        $this->response    = $this->unwrapEncryptedMsg($rawResponse);
-        $this->segments = explode("'", $rawResponse);
+        $this->response = $this->unwrapEncryptedMsg($rawResponse);
+        $this->segments = preg_split("#(')(?=[A-Z]{4,})#", $rawResponse);
     }
 
     /**
@@ -79,11 +85,12 @@ class Response
      * Some kind of HBCI pagination.
      *
      * @param AbstractMessage $message
+     *
      * @return array
      */
     public function getTouchDowns(AbstractMessage $message)
     {
-        $touchdown = array();
+        $touchdown = [];
         $messageSegments = $message->getEncryptedSegments();
         /** @var AbstractSegment $msgSeg */
         foreach ($messageSegments as $msgSeg) {
@@ -184,16 +191,17 @@ class Response
 
     /**
      * @param string $name
+     *
      * @return array
      * @throws \Exception
      */
     protected function getSummaryBySegment($name)
     {
-        if (!in_array($name, array('HIRMS', 'HIRMG'))) {
+        if (!in_array($name, ['HIRMS', 'HIRMG'])) {
             throw new \Exception('Invalid segment for message summary. Only HIRMS and HIRMG supported');
         }
 
-        $result = array();
+        $result = [];
         $segment = $this->findSegment($name);
         $segment = $this->splitSegment($segment);
         array_shift($segment);
@@ -207,6 +215,7 @@ class Response
 
     /**
      * @param string $segmentName
+     *
      * @return string
      */
     public function getSegmentMaxVersion($segmentName)
@@ -242,13 +251,14 @@ class Response
 
     /**
      * @param bool $translateCodes
+     *
      * @return string
      */
     public function humanReadable($translateCodes = false)
     {
         return str_replace(
-            array("'", '+'),
-            array(PHP_EOL, PHP_EOL . "  "),
+            ["'", '+'],
+            [PHP_EOL, PHP_EOL . "  "],
             $translateCodes
                 ? NameMapping::translateResponse($this->rawResponse)
                 : $this->rawResponse
@@ -256,8 +266,9 @@ class Response
     }
 
     /**
-     * @param string $name
+     * @param string          $name
      * @param AbstractSegment $reference
+     *
      * @return string|null
      */
     protected function findSegmentForReference($name, AbstractSegment $reference)
@@ -278,6 +289,7 @@ class Response
 
     /**
      * @param string $name
+     *
      * @return array|null|string
      */
     protected function findSegment($name)
@@ -287,12 +299,13 @@ class Response
 
     /**
      * @param string $name
-     * @param bool $one
+     * @param bool   $one
+     *
      * @return array|null|string
      */
     protected function findSegments($name, $one = false)
     {
-        $found = $one ? null : array();
+        $found = $one ? null : [];
 
         foreach ($this->segments as $segment) {
             $split = explode(':', $segment, 2);
@@ -310,6 +323,7 @@ class Response
 
     /**
      * @param $segment
+     *
      * @return array
      */
     protected function splitSegment($segment)
@@ -321,6 +335,7 @@ class Response
 
     /**
      * @param $deg
+     *
      * @return array
      */
     protected function splitDeg($deg)
@@ -330,7 +345,8 @@ class Response
 
     /**
      * @param int $idx
-     * @param $segment
+     * @param     $segment
+     *
      * @return string|null
      */
     protected function getSegmentIndex($idx, $segment)
@@ -345,6 +361,7 @@ class Response
 
     /**
      * @param string $response
+     *
      * @return string
      */
     protected function unwrapEncryptedMsg($response)


### PR DESCRIPTION
I've faced a strange bug where a single quote in the payer's name could lead into missing results.

Below there is an sample raw response excerpt which containts two single quotes in line 7:

```
:20:STARTUMSE
:25:12340000/1005751234
:28C:00000/001
:60F:C160813EUR8575,66
:61:1609140814CR89,37N062NONREF
:86:166?00GUTSCHRIFT?109253?20SVWZ+FooBarBaz Example?21Foo
Bar?30GENOEDF1SN1?31DE50140912340005719216?32'Example Company Name' GmbH
:61:1609140814CR70,82N062NONREF
:86:166?00GUTSCHRIFT?108249?20EREF+Max Mustermann 
:86:166?00GUTSCHRIFT?108227?20SVWZ+Example Message?30SOLADES1R
VB?31DE16612301100111887741?32SomeOtherGuy
:62F:C160914EUR8785,85
```

After some debugging, i found out that  in Fhp\Response\Response::__construct() a simple explode is used to separate the response into segments. However, if other strings containts unexpected quotes, the rest of the response is not parsed properly.

The solution is to split the raw response more precisely: The split is done when a single quote is followed by four or more uppercase characters, a colon and a number.
The chance,  that a payers name looks like _'FOOBAR:7_ is very low.

Additionally, i added empty lines between class properties and shortened `array()` to `[]`
