### PR TITLE
Better error reporting for Curl failures

### DIFF
--- a/lib/Fhp/Adapter/Curl.php
+++ b/lib/Fhp/Adapter/Curl.php
@@ -77,7 +77,12 @@ class Curl implements AdapterInterface
         $this->lastResponseInfo = curl_getinfo($this->curlHandle);
 
         if (false === $response) {
-            throw new CurlException('Failed connection to ' . $this->host, 0, null, $this->lastResponseInfo);
+            throw new CurlException(
+                'Failed connection to ' . $this->host . ': ' . curl_error($this->curlHandle),
+                curl_errno($this->curlHandle),
+                null,
+                $this->lastResponseInfo
+            );
         }
 
         $statusCode = curl_getinfo($this->curlHandle, CURLINFO_HTTP_CODE);


### PR DESCRIPTION
When no HTTP status was received, include the error number and error message returned by Curl into the CurlException, as this will give the best clues for debugging.