### PR TITLE
Fix for broken account data if a line break exists between ? and Sepa-Subfield-Number

### DIFF
--- a/lib/Fhp/Parser/MT940.php
+++ b/lib/Fhp/Parser/MT940.php
@@ -154,7 +154,7 @@ class MT940
         }
 
         $descr = str_replace('? ', '?', $descr);
-        preg_match_all('/\?(\d{2})([^\?]+)/', $descr, $matches, PREG_SET_ORDER);
+        preg_match_all('/\?[\r\n]*(\d{2})([^\?]+)/', $descr, $matches, PREG_SET_ORDER);
 
         $descriptionLines = array();
         $description1 = ''; // Legacy, could be removed.


### PR DESCRIPTION
In example for this statement the original regex did not mach:

```
:86:116?00EINZELUEBERWEISUNG?109000?20KREF+AHYE201700000000000?21\r\n
SVWZ+RE 20170000 VOM 27.07.?222017 KD 34 ABCDEF?30GENXXXXXXXX?\r\n
31DE25000000000000000000?32ABCDEF?34997\r\n
```