### PR TITLE
Feature: Added "Satzart" to distinguish booke transactions from interim transactions

### DIFF
--- a/lib/Fhp/Model/StatementOfAccount/Transaction.php
+++ b/lib/Fhp/Model/StatementOfAccount/Transaction.php
@@ -68,6 +68,11 @@ class Transaction
     protected $name;
 
     /**
+     * @var string
+     */
+    protected $satzart;
+
+    /**
      * Get booking date.
      *
      * @deprecated Use getBookingDate() instead
@@ -356,4 +361,19 @@ class Transaction
 
         return $this;
     }
+
+    /**
+     * @return string
+     */
+    public function getSatzart() {
+        return $this->satzart;
+    }
+
+    /**
+     * @param string $satzart
+     */
+    public function setSatzart($satzart) {
+        $this->satzart = $satzart;
+    }
+
 }

--- a/lib/Fhp/Parser/MT940.php
+++ b/lib/Fhp/Parser/MT940.php
@@ -154,7 +154,7 @@ class MT940
         }
 
         $descr = str_replace('? ', '?', $descr);
-        preg_match_all('/\?(\d{2})([^\?]+)/', $descr, $matches, PREG_SET_ORDER);
+        preg_match_all('/\?[\r\n]*(\d{2})([^\?]+)/', $descr, $matches, PREG_SET_ORDER);
 
         $descriptionLines = array();
         $description1 = ''; // Legacy, could be removed.

--- a/lib/Fhp/Parser/MT940.php
+++ b/lib/Fhp/Parser/MT940.php
@@ -57,12 +57,17 @@ class MT940
 
         $result = array();
         $days = preg_split('%' . $divider . '-$%', $this->rawData);
+        $satzart = '';
         foreach ($days as &$day) {
             $day = explode($divider . ':', $day);
             for ($i = 0, $cnt = count($day); $i < $cnt; $i++) {
+                if (preg_match('/^20:/', $day[$i])) {
+                    // Satzart
+                    $satzart = substr($day[$i], 3);
+                }
                 // handle start balance
                 // 60F:C160401EUR1234,56
-                if (preg_match('/^60(F|M):/', $day[$i])) {
+                elseif (preg_match('/^60(F|M):/', $day[$i])) {
                     // remove 60(F|M): for better parsing
                     $day[$i] = substr($day[$i], 4);
                     $this->soaDate = $this->getDate(substr($day[$i], 1, 6));
@@ -132,7 +137,7 @@ class MT940
 
                     $trx[count($trx) - 1]['booking_date'] = $bookingDate;
                     $trx[count($trx) - 1]['valuta_date'] = $valutaDate;
-                }
+                    $trx[count($trx) - 1]['satzart'] = $satzart;                }
             }
         }
 

--- a/lib/Fhp/Response/GetStatementOfAccount.php
+++ b/lib/Fhp/Response/GetStatementOfAccount.php
@@ -72,6 +72,7 @@ class GetStatementOfAccount extends Response
                     $transaction->setValutaDate(new \DateTime($trx['valuta_date']));
                     $transaction->setCreditDebit($trx['credit_debit']);
                     $transaction->setAmount($trx['amount']);
+                    $transaction->setSatzart($trx['satzart']);
                     $transaction->setBookingText($trx['description']['booking_text']);
                     $transaction->setDescription1($trx['description']['description_1']);
                     $transaction->setDescription2($trx['description']['description_2']);


### PR DESCRIPTION
At the moment there is no way to determine whether transactions already booked or they are interim transactions.

This feature adds "satzart" to transactions  - in german usually "STARTUMS" or "STARTUMSE" and for interim transactions "STARTDISP" or "STARTDISPE".