### PR TITLE
Fix description parsing for empty sections

### DIFF
--- a/lib/Fhp/Parser/MT940.php
+++ b/lib/Fhp/Parser/MT940.php
@@ -187,7 +187,7 @@ class MT940
         } else {
             $lastType = null;
             foreach ($descriptionLines as $line) {
-                if (strlen($line) > 5 && $line[4] === '+') {
+                if (strlen($line) >= 5 && $line[4] === '+') {
                     if ($lastType != null) {
                         $description[$lastType] = trim($description[$lastType]);
                     }


### PR DESCRIPTION
The MT940 structured description parser currently outputs a PHP "notice" when a section in the structured description is completely empty (e.g. `...?20EREF+                      ?....`). Depending on the PHP configuration, this notice can cause the entire program to abort. This commit allows empty sections, which will be output with their respective key and an empty string as the value.