### PR TITLE
Support fees for foreign currency transfers in credit cards on Consor…

### DIFF
--- a/lib/Fhp/Parser/MT940.php
+++ b/lib/Fhp/Parser/MT940.php
@@ -187,7 +187,7 @@ class MT940
         } else {
             $lastType = null;
             foreach ($descriptionLines as $line) {
-                if (strlen($line) > 5 && $line[4] === '+' || is_null($lastType) && $line === 'EREF+') {
+                if (strlen($line) >= 5 && $line[4] === '+') {
                     if ($lastType != null) {
                         $description[$lastType] = trim($description[$lastType]);
                     }

--- a/lib/Fhp/Parser/MT940.php
+++ b/lib/Fhp/Parser/MT940.php
@@ -187,7 +187,7 @@ class MT940
         } else {
             $lastType = null;
             foreach ($descriptionLines as $line) {
-                if (strlen($line) > 5 && $line[4] === '+') {
+                if (strlen($line) > 5 && $line[4] === '+' || is_null($lastType) && $line === 'EREF+') {
                     if ($lastType != null) {
                         $description[$lastType] = trim($description[$lastType]);
                     }


### PR DESCRIPTION
…sbank

I ran into a problem where the parser did not recognize the an entry for foreign currency data. The reason was that the initial limit of >5 chars for new entries was to low, since it only was "EREF+". It seems that there is no special party in this kind of transactions and it is therefor left empty. To support it, I added the ability to allow exactly this "EREF+" definition.