### PR TITLE
take into account empty description lines like "EREF+"

### DIFF
--- a/lib/Fhp/Parser/MT940.php
+++ b/lib/Fhp/Parser/MT940.php
@@ -187,7 +187,7 @@ class MT940
         } else {
             $lastType = null;
             foreach ($descriptionLines as $line) {
-                if (strlen($line) > 5 && $line[4] === '+') {
+                if (strlen($line) >= 5 && $line[4] === '+') {
                     if ($lastType != null) {
                         $description[$lastType] = trim($description[$lastType]);
                     }


### PR DESCRIPTION
Hello,

in my case, the method parseDescription() received the following string from Consorsbank:

```
$string = "
005?00Lastschrift (Einzugsermächtigung)?20EREF+                  \r\n
    ?21             ?22KREF+NONREF?23SVWZ+VISA11111111NAMENA-SCH?\r\n
24MEN 123,00EUR0,0000000000 0?255.05.        0,00 11111111?312103\r\n
0121?123212321236?32HSO*NAMENA&NAMENAMEN
";
```
the condition in MT940.php:190 was not applicable, since `$line` was only `"EREF+"`, without anything after the `+`. For this reason `$lastType` was `null` and an undefined index error was thrown.