### PR TITLE
added Raiffeisenbank Main-Spessart as compatible bank

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -533,6 +533,7 @@ This library is verified to work with following banks.
 - [ ] Raiffeisenbank Leezen eG
 - [ ] Raiffeisenbank Lorup eG
 - [x] Raiffeisenbank Maintal Ndl d Frankfurter VB
+- [x] Raiffeisenbank Main-Spessart
 - [ ] Raiffeisenbank Maitis
 - [ ] Raiffeisenbank Malchin eG
 - [ ] Raiffeisenbank Mangfalltal -alt-


### PR DESCRIPTION
HBCI-Server URL can be found here: https://www.raiba-msp.de/Firmenkunden/Zahlungsverkehr/Electronic-Banking/Banking-Hilfe-und-Anleitungen/c1103.html