### PR TITLE
Update MT940.php

### DIFF
--- a/lib/Fhp/Parser/MT940.php
+++ b/lib/Fhp/Parser/MT940.php
@@ -108,7 +108,7 @@ class MT940
 
                     $amount = $trxMatch[4];
                     $amount = str_replace(',', '.', $amount);
-                    $trx[count($trx) - 1]['amount'] = floatval($amount);
+                    $trx[count($trx) - 1]['amount'] = $amount;
 
                     $description = $this->parseDescription($description);
                     $trx[count($trx) - 1]['description'] = $description;


### PR DESCRIPTION
Problems with floatingpointprecission: 
If the amount is e.g. 9.36 then this floatval produces 9.359999999999999 what results in getAmount on Transaction giving this back.
It should be kept as a string, and the user can decide wether he want's to use it as a float or not...