### PR TITLE
Update FinTs.php

### DIFF
--- a/lib/Fhp/FinTs.php
+++ b/lib/Fhp/FinTs.php
@@ -188,7 +188,7 @@ class FinTs
                 $account,
                 $from,
                 $to,
-                $touchdowns[HKKAZ::NAME]
+                $this->escapeString($touchdowns[HKKAZ::NAME])
             );
 
             $r = $dialog->sendMessage($message);


### PR DESCRIPTION
escape touchdown-string to mask "+" correctly - solves "9050 - Die Nachricht enthält Fehler. (TRE)". See also https://github.com/mschindler83/fints-hbci-php/issues/93