### PR TITLE
#129 Expose product name/version from FinTs constructor

### DIFF
--- a/lib/Fhp/Dialog/Dialog.php
+++ b/lib/Fhp/Dialog/Dialog.php
@@ -85,6 +85,16 @@ class Dialog
     protected $hkkazVersion = 6;
 
     /**
+     * @var string
+     */
+    protected $productName;
+
+    /**
+     * @var string
+     */
+    protected $productVersion;
+
+    /**
      * Dialog constructor.
      *
      * @param Connection $connection
@@ -92,15 +102,19 @@ class Dialog
      * @param string $username
      * @param string $pin
      * @param string $systemId
+     * @param string $productName
+     * @param string $productVersion
      * @param LoggerInterface $logger
      */
-    public function __construct(Connection $connection, $bankCode, $username, $pin, $systemId, LoggerInterface $logger)
+    public function __construct(Connection $connection, $bankCode, $username, $pin, $systemId, $productName, $productVersion, LoggerInterface $logger)
     {
         $this->connection = $connection;
         $this->bankCode = $bankCode;
         $this->username = $username;
         $this->pin = $pin;
         $this->systemId = $systemId;
+        $this->productName = $productName;
+        $this->productVersion = $productVersion;
         $this->logger = $logger;
     }
 
@@ -266,7 +280,9 @@ class Dialog
     {
         $this->logger->info('Initialize Dialog');
         $identification = new HKIDN(3, $this->bankCode, $this->username, $this->systemId);
-        $prepare        = new HKVVB(4, HKVVB::DEFAULT_BPD_VERSION, HKVVB::DEFAULT_UPD_VERSION, HKVVB::LANG_DEFAULT);
+        $prepare        = new HKVVB(4, HKVVB::DEFAULT_BPD_VERSION,
+            HKVVB::DEFAULT_UPD_VERSION, HKVVB::LANG_DEFAULT,
+            $this->productName, $this->productVersion);
 
         $message = new Message(
             $this->bankCode,
@@ -308,7 +324,9 @@ class Dialog
         $this->dialogId = 0;
 
         $identification = new HKIDN(3, $this->bankCode, $this->username, 0);
-        $prepare        = new HKVVB(4, HKVVB::DEFAULT_BPD_VERSION, HKVVB::DEFAULT_UPD_VERSION, HKVVB::LANG_DEFAULT);
+        $prepare        = new HKVVB(4, HKVVB::DEFAULT_BPD_VERSION,
+            HKVVB::DEFAULT_UPD_VERSION, HKVVB::LANG_DEFAULT,
+            $this->productName, $this->productVersion);
         $sync           = new HKSYN(5);
 
         $syncMsg = new Message(

--- a/lib/Fhp/FinTs.php
+++ b/lib/Fhp/FinTs.php
@@ -53,11 +53,12 @@ class FinTs
 
     /**
      * FinTs constructor.
-     * @param string $server
-     * @param int $port
-     * @param string $bankCode
-     * @param string $username
-     * @param string $pin
+     * @param string $server Base URL (should start with https://) where the bank's server can be reached.
+     * @param int $port The port to use for the connection. Use 443 for HTTPS.
+     * @param string $bankCode The bank's identifier (Bankleitzahl).
+     * @param string $username The username for authentication. This is assigned by the bank initially, but most banks
+     *     allow users to customize it.
+     * @param string $pin The PIN for authentication.
      * @param LoggerInterface|null $logger
      */
     public function __construct(

--- a/lib/Fhp/FinTs.php
+++ b/lib/Fhp/FinTs.php
@@ -50,6 +50,10 @@ class FinTs
     protected $systemId = 0;
     /** @var string */
     protected $bankName;
+    /** @var string */
+    protected $productName;
+    /** @var string */
+    protected $productVersion;
 
     /**
      * FinTs constructor.
@@ -59,6 +63,12 @@ class FinTs
      * @param string $username The username for authentication. This is assigned by the bank initially, but most banks
      *     allow users to customize it.
      * @param string $pin The PIN for authentication.
+     * @param string $productName Identifies the product (i.e. the application in which the fints-hbci-php library is
+     *     being used). This is used to show users which products/applications have access to their bank account. Note
+     *     that this shouldn't just be an arbitrary string, but rather the registration number obtained from the
+     *     registration on https://www.hbci-zka.de/register/prod_register.htm.
+     * @param string $productVersion The product version, which can be an arbitrary string, though if your the
+     *     application displays a version number somewhere on its own user interface, it should match that.
      * @param LoggerInterface|null $logger
      */
     public function __construct(
@@ -67,6 +77,8 @@ class FinTs
         $bankCode,
         $username,
         $pin,
+        $productName,
+        $productVersion,
         LoggerInterface $logger = null
     ) {
         $this->server = $server;
@@ -83,6 +95,9 @@ class FinTs
         // HBCI special chars.
         $this->username = $this->escapeString($username);
         $this->pin = $this->escapeString($pin);
+
+        $this->productName = $productName;
+        $this->productVersion = $productVersion;
 
         $this->adapter = new Curl($this->server, $this->port);
         $this->connection = new Connection($this->adapter);
@@ -413,6 +428,8 @@ class FinTs
             $this->username,
             $this->pin,
             $this->systemId,
+            $this->productName,
+            $this->productVersion,
             $this->logger
         );
     }

--- a/lib/Fhp/Segment/HKVVB.php
+++ b/lib/Fhp/Segment/HKVVB.php
@@ -24,9 +24,6 @@ class HKVVB extends AbstractSegment
     const LANG_EN = 2;
     const LANG_FR = 3;
 
-    const DEFAULT_PRODUCT_NAME = 'fints-hbci-php';
-    const DEFAULT_PRODUCT_VERSION = '1.0';
-
     /**
      * HKVVB constructor.
      * @param int $segmentNumber
@@ -38,11 +35,11 @@ class HKVVB extends AbstractSegment
      */
     public function __construct(
         $segmentNumber,
-        $bpdVersion = self::DEFAULT_BPD_VERSION,
-        $updVersion = self::DEFAULT_UPD_VERSION,
-        $dialogLanguage = self::LANG_DEFAULT,
-        $productName = self::DEFAULT_PRODUCT_NAME,
-        $productVersion = self::DEFAULT_PRODUCT_VERSION
+        $bpdVersion,
+        $updVersion,
+        $dialogLanguage,
+        $productName,
+        $productVersion
     ) {
         parent::__construct(
             static::NAME,


### PR DESCRIPTION
This closes #129 and replaces #97. See https://www.hbci-zka.de/register/prod_register.htm for context.

This is a breaking change and needs a major version bump, plus a hint to users that they need to register and pass two more parameters to the constructor.